### PR TITLE
fix: deno compile エラーを修正

### DIFF
--- a/ken-all-mcp.ts
+++ b/ken-all-mcp.ts
@@ -1,5 +1,4 @@
 /// <reference lib="deno.ns" />
-/// <reference types="https://deno.land/x/typescript/lib/lib.deno.ns.d.ts" />
 
 import { Server } from "npm:@modelcontextprotocol/sdk@1.5.0/server/index.js";
 import { StdioServerTransport } from "npm:@modelcontextprotocol/sdk@1.5.0/server/stdio.js";
@@ -96,7 +95,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
           content: [
             {
               type: "text",
-              text: `Error reading file: ${error.message}`,
+              text: `Error reading file: ${(error as Error).message}`,
             },
           ],
           isError: true,


### PR DESCRIPTION
## 修正内容

- 不要な参照パス `/// <reference types="https://deno.land/x/typescript/lib/lib.deno.ns.d.ts" />` を削除
- `error` 変数を `Error` 型としてキャストして、`message` プロパティにアクセスできるようにした

## 確認方法

`deno compile --allow-read ken-all-mcp.ts` コマンドが正常に実行できることを確認